### PR TITLE
Fixed valueRange not updating in SwiftUI

### DIFF
--- a/Sources/SliderControl/SliderControlView.swift
+++ b/Sources/SliderControl/SliderControlView.swift
@@ -96,6 +96,7 @@ public struct SliderControlView<T: BinaryFloatingPoint>: UIViewRepresentable {
         uiView.defaultProgressColor = defaultProgressColor
         uiView.enlargedTrackColor = enlargedTrackColor
         uiView.enlargedProgressColor = enlargedProgressColor
+        control.valueRange = Float(valueRange.lowerBound)...Float(valueRange.upperBound)
     }
 }
 


### PR DESCRIPTION
I have a SwiftUI setup where the valueRange might not be known initially, so the `SliderControl` would always have it's range `0...0`. 

Now, the value range change is from SwiftUI is represented in UIKit.